### PR TITLE
Update Swagger-UI to v5 to be compatible with latest fastapi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ def download_cdn_files()  -> None:
     static_path = Path(__file__).parent / PROJECT_NAME
     static_path.mkdir(parents=True, exist_ok=True)
     for cdn_url in (
-        "https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui.css",
-        "https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui-bundle.js",
+        "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+        "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
     ):
         urlretrieve(cdn_url, static_path / cdn_url.split("/")[-1])
 


### PR DESCRIPTION
Fastapi is using openapi version 3.1.0 [as default](https://github.com/tiangolo/fastapi/blob/f7e3559bd5997f831fb9b02bef9c767a50facbc3/fastapi/applications.py#L115). For openapi 3.1.0 [one must use swagger-ui v5](https://github.com/swagger-api/swagger-ui#compatibility), since the previous versions do not support it. As a result, I propose to change the swagger-ui version to v5.

Besides, v5 also supports all previous versions, so I don't see any disadvantage in switching